### PR TITLE
Support default input for local

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,10 +8,11 @@ const {
     gotoFunction,
     getSearchType,
     hasReachedScrapeLimit,
+    validateInput,
 } = require('./tools');
 
 Apify.main(async () => {
-    const input = await Apify.getInput();
+    const input = validateInput(await Apify.getInput());
 
     const dataset = await Apify.openDataset();
     let { itemCount } = await dataset.getInfo();
@@ -28,10 +29,6 @@ Apify.main(async () => {
         useBuiltInSearch,
         type,
     } = input;
-
-    if (!startUrls && !useBuiltInSearch) {
-        throw new Error('startUrls or built-in search must be used!');
-    }
 
     const requestList = await Apify.openRequestList(
         'start-urls',

--- a/src/tools.js
+++ b/src/tools.js
@@ -100,3 +100,39 @@ exports.convertRelativeDate = (passedTimeString) => {
 exports.hasReachedScrapeLimit = ({ maxItems, itemCount }) => {
     return itemCount >= maxItems;
 };
+exports.defaultInput = {
+    proxy: '',
+    startUrls: [],
+    searches: [],
+    extendOutputFunction: '',
+    maxItems: 50,
+    maxPostCount: 50,
+    maxComments: 50,
+    maxCommunitiesAndUsers: 50,
+    useBuiltInSearch: false,
+    type: 'Posts',
+    proxyConfiguration: { useApifyProxy: true },
+};
+
+exports.validateInput = (input) => {
+    if (input.useBuiltInSearch === undefined) {
+        log.warning('Input: built-in search is not set, set true as default');
+    }
+    if (input.searches === undefined) {
+        log.warning('Input: searches is not set, set [] as default.');
+    }
+    if (input.startUrls === undefined) {
+        log.warning('Input: startUrls is not set, set [] as default.');
+    }
+    const newInput = { ...exports.defaultInput, ...input };
+    if (newInput.useBuiltInSearch && newInput.searches.length === 0) {
+        log.warning('Empty searches with built-in search found.');
+    }
+    if (newInput.startUrls.length === 0) {
+        log.warning('Empty startUrls found.');
+    }
+    if (!newInput.useBuiltInSearch && newInput.startUrls.length === 0) {
+        log.error('startUrls or built-in search must be used!');
+    }
+    return newInput;
+};


### PR DESCRIPTION
#6 
I added default input values and log messages.
* setting based on README.md
* npm start can do all flow with default setting when no key exists.
* log warn and error